### PR TITLE
Allow setting Weave scope to read only

### DIFF
--- a/modules/weave-scope/README.md
+++ b/modules/weave-scope/README.md
@@ -61,6 +61,7 @@ No modules.
 | <a name="input_ingress_host"></a> [ingress\_host](#input\_ingress\_host) | Ingress host name used for Ingress configuration | `string` | `""` | no |
 | <a name="input_ingress_name"></a> [ingress\_name](#input\_ingress\_name) | Ingress name to configure in helm chart | `string` | `"weave-ingress"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace, in which Weave Scope will be deployed | `string` | `"meta-system"` | no |
+| <a name="input_read_only"></a> [read\_only](#input\_read\_only) | Whether to disable write operations in weave frontend | `bool` | `false` | no |
 | <a name="input_release_name"></a> [release\_name](#input\_release\_name) | Helm chart release name | `string` | `"weave-scope"` | no |
 | <a name="input_service_type"></a> [service\_type](#input\_service\_type) | Service type configuration Valid attributes are NodePort, LoadBalancer, ClusterIP | `string` | `"ClusterIP"` | no |
 

--- a/modules/weave-scope/main.tf
+++ b/modules/weave-scope/main.tf
@@ -14,6 +14,7 @@ resource "helm_release" "weave-scope" {
         ingress_host  = var.ingress_host
         ingress_name  = var.ingress_name
         ingress_class = var.ingress_class
+        read_only     = var.read_only
     })
   ]
 }

--- a/modules/weave-scope/resources/values.yaml.tpl
+++ b/modules/weave-scope/resources/values.yaml.tpl
@@ -33,6 +33,6 @@ weave-scope-agent:
   probeToken: ""
   rbac:
     create: true
-  readOnly: false
+  readOnly: ${read_only}
   serviceAccount:
     create: true

--- a/modules/weave-scope/variables.tf
+++ b/modules/weave-scope/variables.tf
@@ -49,3 +49,9 @@ variable "ingress_name" {
   type        = string
   default     = "weave-ingress"
 }
+
+variable "read_only" {
+  description = "Whether to disable write operations in weave frontend"
+  type        = bool
+  default     = false
+}

--- a/modules/weave-scope/variables.tf
+++ b/modules/weave-scope/variables.tf
@@ -40,7 +40,7 @@ variable "service_type" {
   default     = "ClusterIP"
   validation {
     condition     = contains(["NodePort", "LoadBalancer", "ClusterIP"], var.service_type)
-    error_message = "The valid attributes are [NodePort], [LoadBalancer], [ClusterIP]"
+    error_message = "The valid attributes are [NodePort], [LoadBalancer], [ClusterIP]."
   }
 }
 


### PR DESCRIPTION
Setting weave scope to read only mode also disables shells for containers and also `hosts` (i.e. kubernetes nodes/VMs)