### PR TITLE
feat(cloudwatch-metrics): make prometheus metrics debug log configurable

### DIFF
--- a/modules/cloudwatch-metrics/README.md
+++ b/modules/cloudwatch-metrics/README.md
@@ -61,7 +61,8 @@ No modules.
 | <a name="input_enable_prometheus_metrics"></a> [enable\_prometheus\_metrics](#input\_enable\_prometheus\_metrics) | n/a | `bool` | `false` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | namespace cloudwatch metrics should be deployed into | `string` | `"amazon-cloudwatch"` | no |
 | <a name="input_oidc_provider_arn"></a> [oidc\_provider\_arn](#input\_oidc\_provider\_arn) | n/a | `string` | n/a | yes |
-| <a name="input_prometheus_metrics_chart_version"></a> [prometheus\_metrics\_chart\_version](#input\_prometheus\_metrics\_chart\_version) | Version of the prometheus metrics chart to use | `string` | `"0.1.0"` | no |
+| <a name="input_prometheus_metrics_chart_version"></a> [prometheus\_metrics\_chart\_version](#input\_prometheus\_metrics\_chart\_version) | Version of the prometheus metrics chart to use | `string` | `"0.2.0"` | no |
+| <a name="input_prometheus_metrics_debug"></a> [prometheus\_metrics\_debug](#input\_prometheus\_metrics\_debug) | Enable debug logging for the prometheus metrics chart | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region name. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/cloudwatch-metrics/main.tf
+++ b/modules/cloudwatch-metrics/main.tf
@@ -78,6 +78,11 @@ resource "helm_release" "aws-cloudwatch-metrics-prometheus" {
     value = "arn:aws:iam::${var.account_id}:role/${aws_iam_role.aws-cloudwatch-metrics-role.name}"
   }
 
+  set {
+    name  = "debug"
+    value = var.prometheus_metrics_debug
+  }
+
   depends_on = [
     kubernetes_namespace.namespace
   ]

--- a/modules/cloudwatch-metrics/variables.tf
+++ b/modules/cloudwatch-metrics/variables.tf
@@ -53,5 +53,11 @@ variable "enable_prometheus_metrics" {
 variable "prometheus_metrics_chart_version" {
   description = "Version of the prometheus metrics chart to use"
   type        = string
-  default     = "0.1.0"
+  default     = "0.2.0"
+}
+
+variable "prometheus_metrics_debug" {
+  description = "Enable debug logging for the prometheus metrics chart"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
This MR can be merged after https://github.com/dasmeta/helm/pull/47 is merged and the new helm chart is released