### PR TITLE
fix: upgrade aws-load-balancer-controller chart to 3.4.2

### DIFF
--- a/modules/aws-load-balancer-controller/README.md
+++ b/modules/aws-load-balancer-controller/README.md
@@ -117,7 +117,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_chart"></a> [chart](#input\_chart) | Chart source settings. name can be a chart name or a direct packaged-chart URL ending with .tgz; repository is ignored for direct URLs. | <pre>object({<br/>    version    = optional(string, "3.3.0")<br/>    repository = optional(string, "https://aws.github.io/eks-charts")<br/>    name       = optional(string, "aws-load-balancer-controller")<br/>  })</pre> | `{}` | no |
+| <a name="input_chart"></a> [chart](#input\_chart) | Chart source settings. name can be a chart name or a direct packaged-chart URL ending with .tgz; repository is ignored for direct URLs. | <pre>object({<br/>    version    = optional(string, "3.4.2")<br/>    repository = optional(string, "https://aws.github.io/eks-charts")<br/>    name       = optional(string, "aws-load-balancer-controller")<br/>  })</pre> | `{}` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | eks cluster name | `string` | `""` | no |
 | <a name="input_configs"></a> [configs](#input\_configs) | Configurations to pass and override default ones. Check the chart values here: https://artifacthub.io/packages/helm/aws/aws-load-balancer-controller | `any` | `{}` | no |
 | <a name="input_create_namespace"></a> [create\_namespace](#input\_create\_namespace) | wether or no to create namespace | `bool` | `false` | no |

--- a/modules/aws-load-balancer-controller/examples/basic/1-example.tf
+++ b/modules/aws-load-balancer-controller/examples/basic/1-example.tf
@@ -5,7 +5,7 @@ module "this" {
   region       = "eu-central-1"
 
   chart = {
-    version = "3.3.0"
+    version = "3.4.2"
   }
   configs = {
     replicaCount = 1

--- a/modules/aws-load-balancer-controller/variables.tf
+++ b/modules/aws-load-balancer-controller/variables.tf
@@ -47,7 +47,7 @@ variable "enable_waf" {
 
 variable "chart" {
   type = object({
-    version    = optional(string, "3.3.0")
+    version    = optional(string, "3.4.2")
     repository = optional(string, "https://aws.github.io/eks-charts")
     name       = optional(string, "aws-load-balancer-controller")
   })

--- a/specs/003-upgrade-alb-controller-version/contracts/module-interface.md
+++ b/specs/003-upgrade-alb-controller-version/contracts/module-interface.md
@@ -1,0 +1,24 @@
+# Module Interface Contract
+
+## Scope
+This contract covers the version-default change for `modules/aws-load-balancer-controller`. No input or output shape changes are introduced.
+
+## Default delta
+- `chart.version`: `3.3.0` -> `3.4.2`.
+- `chart.repository`, `chart.name`: unchanged.
+- `image.repository`, `image.tag`: unchanged (null by default; controller image follows the chart `appVersion`).
+
+## Compatibility rules
+- Consumers who set `chart.version` are unaffected (pins win).
+- No new required inputs; no removed inputs; no output changes (`iam_policy_arn` and other outputs unchanged).
+
+## IAM policy contract
+- The vendored `iam-policy.json` MUST match the upstream controller policy for the deployed version.
+- For this bump, the upstream policy is unchanged between the previous and target versions and the vendored copy already matches, so the policy is unchanged.
+- If a future bump introduces an upstream permission delta, the vendored policy MUST be refreshed as part of that change.
+
+## Provider / version constraints
+- `versions.tf` is unchanged (no provider constraint impact).
+
+## Cross-cutting
+- No breaking changes; no interface widening.

--- a/specs/003-upgrade-alb-controller-version/data-model.md
+++ b/specs/003-upgrade-alb-controller-version/data-model.md
@@ -1,0 +1,34 @@
+# Data Model: Upgrade AWS Load Balancer Controller Chart Version
+
+## Entity: Chart Version Baseline
+- **Description**: The default Helm chart version for the controller and, by extension, the controller image via the chart `appVersion`.
+- **Fields**:
+  - `chart.version`: default chart version (`3.4.2`)
+  - `chart.repository`: chart repository (`https://aws.github.io/eks-charts`, unchanged)
+  - `chart.name`: chart name or direct `.tgz` URL (`aws-load-balancer-controller`, unchanged)
+- **Validation rules**:
+  - Must reference a published, stable chart version.
+  - Consumers who set `chart.version` override the default.
+  - Backward-compatible for consumers who do not pin the version.
+- **Relationships**:
+  - Determines the controller image when `image.tag` is unset.
+
+## Entity: Controller Image Override
+- **Description**: Optional explicit controller image, off by default.
+- **Fields**:
+  - `image.repository`: image repository (null by default)
+  - `image.tag`: image tag (null by default -> chart default image used)
+- **Validation rules**:
+  - When null, the chart default image (matching the chart `appVersion`) is used.
+
+## Entity: IAM Policy Contract
+- **Description**: The vendored permission set attached to the controller's IAM role, which must match the upstream controller policy for the deployed version.
+- **Fields**:
+  - `iam-policy.json`: vendored policy document
+- **Validation rules**:
+  - MUST be equivalent to the upstream controller `iam_policy.json` for the target version.
+  - Updated only when the upstream policy for the target version differs from the vendored copy.
+- **State transitions**:
+  1. Identify the target controller version (from the chart `appVersion`).
+  2. Compare vendored policy to the upstream policy for that version.
+  3. If a delta exists, refresh the vendored policy; otherwise leave unchanged.

--- a/specs/003-upgrade-alb-controller-version/plan.md
+++ b/specs/003-upgrade-alb-controller-version/plan.md
@@ -1,0 +1,82 @@
+# Implementation Plan: Upgrade AWS Load Balancer Controller Chart Version
+
+**Branch**: `003-upgrade-alb-controller-version` | **Date**: 2026-07-21 | **Spec**: `specs/003-upgrade-alb-controller-version/spec.md`
+**Input**: Feature specification from `/specs/003-upgrade-alb-controller-version/spec.md`
+
+## Summary
+
+Bump the `aws-load-balancer-controller` module default chart `version` from `3.3.0` to `3.4.2` (latest stable on `eks-charts`). The controller image follows the chart `appVersion` automatically (`v3.4.2`) because `image.tag` defaults to null. The vendored `iam-policy.json` was verified equivalent to the upstream controller policy for both `v3.3.0` and `v3.4.2`, so no IAM change is required. Update README and the basic example to match. Backward-compatible; consumers who pin the version are unaffected.
+
+## Technical Context
+
+**Terraform/OpenTofu Version**: Terraform `~> 1.3`  
+**Providers / Upstream Modules**: `hashicorp/helm (~> 2.0)`, `aws (> 5.0, < 7.0)`, `aws-load-balancer-controller` Helm chart from `eks-charts`  
+**Target Module Path**: `modules/aws-load-balancer-controller`  
+**Examples / Tests in Scope**: `modules/aws-load-balancer-controller/examples/basic`  
+**Automation Gates**: `pre-commit` hooks (`terraform_fmt`, `terraform_docs`, file hygiene), repo CI checks for Terraform module changes  
+**Target Platform**: Amazon EKS clusters (the controller manages AWS Application/Network Load Balancers; a full functional test requires a real EKS cluster with AWS integration)  
+**Constraints**: Preserve current default behavior aside from the version number; no interface or breaking changes; keep the vendored IAM policy in sync with the deployed controller version  
+**Scale/Scope**: One module plus its README and basic example
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- [x] Change stays within one coherent module responsibility and the current repository scope.
+- [x] Consumer interface remains opinionated; no interface widening (defaults-only change).
+- [x] `README.md` and `examples/` updates are listed for the version change.
+- [x] `versions.tf` provider compatibility reviewed — unchanged.
+- [x] Breaking changes / weakened defaults: none.
+
+Post-design re-check: PASS.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-upgrade-alb-controller-version/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── module-interface.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+modules/aws-load-balancer-controller/
+├── variables.tf                    # chart.version default 3.3.0 -> 3.4.2
+├── README.md                       # generated input table updated to 3.4.2
+├── iam-policy.json                 # verified equivalent to upstream v3.4.2 (unchanged)
+└── examples/
+    └── basic/
+        └── 1-example.tf            # chart version 3.3.0 -> 3.4.2
+```
+
+**Structure Decision**: Keep all work localized to `modules/aws-load-balancer-controller` and its basic example. No new files.
+
+## Phase 0: Research Plan
+
+1. Confirm the latest stable chart version on `eks-charts` and the controller image it maps to (chart `appVersion`).
+2. Compare the upstream controller IAM policy between the previous and target versions to detect any permission delta.
+3. Confirm the vendored `iam-policy.json` matches the upstream policy for the target version.
+4. Define validation: `terraform validate` for module/example plus the IAM-policy equivalence check.
+
+## Phase 1: Design Outputs
+
+- `research.md`: Version target, chart→image mapping, and the IAM-policy equivalence finding.
+- `data-model.md`: The chart-version baseline and IAM-policy contract entities.
+- `contracts/module-interface.md`: Confirmation of an unchanged interface and the single default delta.
+- `quickstart.md`: Maintainer execution + verification flow.
+
+Agent context regeneration is intentionally skipped (not explicitly requested).
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None | Defaults-only version bump with verified IAM parity | N/A |

--- a/specs/003-upgrade-alb-controller-version/quickstart.md
+++ b/specs/003-upgrade-alb-controller-version/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Implement Plan 003
+
+## 1) Confirm workspace state
+1. Ensure branch is `003-upgrade-alb-controller-version`.
+2. Ensure feature artifacts exist under `specs/003-upgrade-alb-controller-version/`.
+3. Baseline default before change: `modules/aws-load-balancer-controller` `chart.version` was `3.3.0`.
+
+## 2) Update the module default
+1. Set `chart.version` default to `3.4.2` in `modules/aws-load-balancer-controller/variables.tf`.
+
+## 3) Verify the IAM policy contract
+1. Determine the controller version for the target chart (chart `appVersion`).
+2. Fetch the upstream controller IAM policy for the previous and target versions:
+   - `https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/<version>/docs/install/iam_policy.json`
+3. Normalize and compare:
+   - upstream previous vs upstream target (detect permission delta)
+   - vendored `iam-policy.json` vs upstream target (confirm equivalence)
+4. If a delta exists, replace `modules/aws-load-balancer-controller/iam-policy.json` with the upstream target policy. If equivalent, leave it unchanged.
+
+## 4) Update docs and example
+1. Update the generated input table default in `modules/aws-load-balancer-controller/README.md`.
+2. Update the pinned version in `modules/aws-load-balancer-controller/examples/basic/1-example.tf`.
+
+## 5) Validate
+1. Format:
+   - `terraform fmt -recursive modules/aws-load-balancer-controller`
+2. Validate module/example:
+   - `cd modules/aws-load-balancer-controller/examples/basic && terraform init -backend=false -input=false && terraform validate`
+3. Confirm:
+   - default chart version resolves to `3.4.2`
+   - vendored IAM policy equals the upstream policy for the target version
+
+## 6) Note on functional testing
+- A full functional test (the controller reconciling real AWS load balancers) requires a real EKS cluster with AWS integration and is exercised by downstream consumers; it is out of scope for module-level validation.
+
+## 7) Downstream compatibility summary
+- Defaults-only bump; no interface changes. Consumers who pin `chart.version` are unaffected. No migration steps required for normal use.

--- a/specs/003-upgrade-alb-controller-version/research.md
+++ b/specs/003-upgrade-alb-controller-version/research.md
@@ -1,0 +1,28 @@
+# Research: Upgrade AWS Load Balancer Controller Chart Version
+
+## Decision 1: Target chart version 3.4.2
+- **Decision**: Set the module default `chart.version` to `3.4.2`.
+- **Rationale**: `3.4.2` is the latest stable `aws-load-balancer-controller` chart on `eks-charts`.
+- **Alternatives considered**:
+  - Stay on `3.3.0`: rejected — does not satisfy the upgrade and misses fixes.
+  - `3.4.0` / `3.4.1`: rejected — superseded by `3.4.2`.
+
+## Decision 2: Let the controller image follow the chart
+- **Decision**: Keep `image.tag` defaulting to null so the chart's default image (its `appVersion`, `v3.4.2`) is used.
+- **Rationale**: Since chart major `3.x` the chart version aligns with the controller version, so the image tracks the chart automatically; a separate image pin would only add drift risk.
+- **Alternatives considered**:
+  - Pin `image.tag` explicitly: rejected — redundant and easy to desync from the chart.
+
+## Decision 3: Verify IAM policy parity (no change needed)
+- **Decision**: Keep the vendored `iam-policy.json` unchanged after confirming it matches the upstream controller policy for the target version.
+- **Rationale**: The most common ALB-controller upgrade break is a change in required IAM permissions. The upstream controller IAM policy was compared between the previous and target versions and found identical, and the vendored policy matches both — so no permission delta exists for this bump.
+- **Verification**: Normalized comparison of the upstream controller `iam_policy.json` for the previous vs target version (identical) and of the vendored policy against the target version (equivalent).
+- **Alternatives considered**:
+  - Blindly refresh the vendored policy: rejected — unnecessary churn when there is no delta.
+  - Skip the IAM check: rejected — this is the highest-risk aspect of the upgrade and must be verified.
+
+## Decision 4: Validation strategy
+- **Decision**: Validate via `terraform validate` for the module and `examples/basic`, plus the IAM-policy equivalence check.
+- **Rationale**: A full functional test of the controller requires a real EKS cluster with AWS integration (the controller reconciles actual load balancers); static validation plus IAM parity is the appropriate module-level gate. Downstream consumers exercise the runtime behavior on real clusters.
+- **Alternatives considered**:
+  - Local non-cloud cluster apply: rejected — the controller cannot manage AWS load balancers without AWS integration, so a local apply would not exercise its real behavior.

--- a/specs/003-upgrade-alb-controller-version/spec.md
+++ b/specs/003-upgrade-alb-controller-version/spec.md
@@ -1,0 +1,81 @@
+# Feature Specification: Upgrade AWS Load Balancer Controller Chart Version
+
+**Feature Branch**: `003-upgrade-alb-controller-version`  
+**Created**: 2026-07-21  
+**Status**: Draft  
+**Input**: User description: "upgrade the aws-load-balancer-controller module chart default to the latest stable release (3.3.0 -> 3.4.2), confirm the vendored IAM policy still matches the target controller version, and keep the change backward-compatible."
+
+## Module Context *(mandatory)*
+
+- **Target Module Path**: `modules/aws-load-balancer-controller`
+- **Related Files In Scope**: `modules/aws-load-balancer-controller/variables.tf`, `modules/aws-load-balancer-controller/README.md`, `modules/aws-load-balancer-controller/examples/basic/1-example.tf`, `modules/aws-load-balancer-controller/iam-policy.json` (verification only)
+- **Upstream Baseline**: `aws-load-balancer-controller` Helm chart from `https://aws.github.io/eks-charts`; vendored IAM policy from the upstream controller release
+- **Requested Interface Change**: Default chart `version` moves `3.3.0 -> 3.4.2`. No input/output shape changes
+- **Breaking Change / Interface Widening**: None. Backward-compatible default bump; consumers who pin the chart version are unaffected
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Consume the up-to-date controller chart by default (Priority: P1)
+
+As a platform engineer, I can consume the module with its default chart version and get the current stable AWS Load Balancer Controller (chart `3.4.2`, controller image `v3.4.2`) without pinning a version myself.
+
+**Why this priority**: Version freshness keeps the controller on a supported, patched release; this is the core purpose of the change.
+
+**Independent Test**: Plan the `examples/basic` configuration with defaults and confirm the chart version resolves to `3.4.2` and the controller image follows the chart's `appVersion`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer using defaults, **When** the module is planned, **Then** the chart version resolves to `3.4.2`.
+2. **Given** a consumer that pins `chart.version`, **When** the module is planned, **Then** the pinned version is honored unchanged.
+
+---
+
+### User Story 2 - IAM policy stays correct for the new controller version (Priority: P2)
+
+As a platform engineer, I can trust that the vendored IAM policy grants exactly the permissions the target controller version requires, so the controller functions without over- or under-privileged access.
+
+**Why this priority**: An ALB controller upgrade most commonly breaks when required IAM permissions change between versions; this must be verified explicitly.
+
+**Independent Test**: Compare the vendored `iam-policy.json` against the upstream controller policy for the target version and confirm they match.
+
+**Acceptance Scenarios**:
+
+1. **Given** the target controller version, **When** the vendored policy is compared to the upstream policy for that version, **Then** they are equivalent (no missing or extra permissions).
+2. **Given** no IAM permission delta between the previous and target controller versions, **When** the chart version is bumped, **Then** no IAM policy change is required.
+
+### Edge Cases
+
+- What happens for consumers who pin `chart.version`? The pin wins; the new default does not force an upgrade.
+- What happens to the controller image? `image.tag` defaults to null, so the chart's default image (matching its `appVersion`) is used — the image follows the chart bump automatically.
+- What if a future controller version DOES change required IAM permissions? The vendored `iam-policy.json` must be refreshed from the upstream policy for that version as part of the bump.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The module MUST default `chart.version` to `3.4.2`.
+- **FR-002**: The controller image MUST continue to follow the chart default when `image.tag` is unset (no separate image pin introduced).
+- **FR-003**: The vendored `iam-policy.json` MUST be verified equivalent to the upstream controller policy for the target version; it is updated only if a delta exists.
+- **FR-004**: `README.md` and `examples/basic` MUST reflect the new default version.
+- **FR-005**: The change MUST preserve existing inputs/outputs; consumers pinning the version MUST be unaffected.
+
+### Compatibility & Delivery Requirements
+
+- **CDR-001**: The target module path and the example/verification files in scope are identified.
+- **CDR-002**: The upstream chart (`eks-charts`) and upstream controller IAM policy are the authoritative sources for the version and permission verification.
+- **CDR-003**: Verification includes `terraform validate` for the module/example and an IAM-policy equivalence check against the upstream policy for the target version.
+- **CDR-004**: No downstream migration is required; the change is a backward-compatible default bump.
+
+### Key Entities *(include if feature involves data or structured configuration)*
+
+- **Chart Version Baseline**: The default chart version (`3.4.2`) that also determines the controller image via the chart `appVersion`.
+- **IAM Policy Contract**: The vendored permission set that must match the upstream controller policy for the deployed version.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Planning the example with defaults resolves the chart to `3.4.2` with no undocumented manual steps.
+- **SC-002**: `terraform validate` passes for the module and `examples/basic`.
+- **SC-003**: The vendored IAM policy is confirmed equivalent to the upstream policy for the target controller version.
+- **SC-004**: README and example reflect the new default version.

--- a/specs/003-upgrade-alb-controller-version/tasks.md
+++ b/specs/003-upgrade-alb-controller-version/tasks.md
@@ -1,0 +1,104 @@
+# Tasks: Upgrade AWS Load Balancer Controller Chart Version
+
+**Input**: Design documents from `/specs/003-upgrade-alb-controller-version/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/module-interface.md`, `quickstart.md`
+
+**Tests**: Verification is `terraform validate` for the module/example plus an IAM-policy equivalence check. Full controller runtime behavior requires a real EKS cluster and is exercised by downstream consumers.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm scope and lock the version baseline.
+
+- [x] T001 Capture the current default (`chart.version = 3.3.0`) as the implementation baseline in `specs/003-upgrade-alb-controller-version/quickstart.md`
+- [x] T002 Confirm latest stable chart version and its controller `appVersion` from the `eks-charts` index
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Verify the IAM policy contract before bumping the chart.
+
+**⚠️ CRITICAL**: The IAM parity check must pass before the version bump is considered safe.
+
+- [x] T003 Fetch the upstream controller IAM policy for the previous and target versions and diff them (result: identical)
+- [x] T004 Diff the vendored `modules/aws-load-balancer-controller/iam-policy.json` against the upstream target policy (result: equivalent -> no policy change needed)
+
+**Milestone**: IAM parity confirmed; the bump is safe.
+
+---
+
+## Phase 3: User Story 1 - Consume the up-to-date controller chart by default (Priority: P1) 🎯 MVP
+
+**Goal**: Move the default chart version to `3.4.2` without breaking default consumer flow.
+
+**Independent Test**: Plan `examples/basic` with defaults and confirm the chart resolves to `3.4.2`.
+
+### Implementation for User Story 1
+
+- [x] T005 [US1] Update `chart.version` default `3.3.0` -> `3.4.2` in `modules/aws-load-balancer-controller/variables.tf`
+- [x] T006 [US1] Update the generated input table default in `modules/aws-load-balancer-controller/README.md`
+- [x] T007 [US1] Update the pinned version in `modules/aws-load-balancer-controller/examples/basic/1-example.tf`
+
+**Milestone**: US1 default updated and independently verifiable.
+
+---
+
+## Phase 4: User Story 2 - IAM policy stays correct for the new controller version (Priority: P2)
+
+**Goal**: Ensure the vendored IAM policy matches the target controller version.
+
+**Independent Test**: Compare vendored policy to the upstream policy for the target version.
+
+### Implementation for User Story 2
+
+- [x] T008 [US2] Confirm no IAM permission delta between previous and target controller versions (verified in Phase 2)
+- [x] T009 [US2] Leave `iam-policy.json` unchanged (equivalent to target); document the parity result in `research.md`
+
+**Milestone**: IAM policy contract verified for the target version.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency and validation.
+
+- [x] T010 [P] Run `terraform fmt -recursive` on `modules/aws-load-balancer-controller`
+- [x] T011 Run `terraform validate` on `modules/aws-load-balancer-controller/examples/basic`
+- [x] T012 Confirm README and example reflect the `3.4.2` default
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: Starts immediately.
+- **Phase 2 (Foundational / IAM parity)**: Depends on Phase 1; blocks the version bump.
+- **Phase 3 (US1)**: Depends on Phase 2.
+- **Phase 4 (US2)**: Verified within Phase 2; documented here.
+- **Phase 5 (Polish)**: Depends on US1/US2.
+
+### Parallel Opportunities
+
+- T006 and T007 can run in parallel after T005.
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2 (IAM parity).
+2. Deliver Phase 3 (US1) version bump end-to-end.
+3. Validate US1 independently as MVP.
+
+### Incremental Delivery
+
+1. Foundation (Phases 1-2): confirm IAM parity.
+2. US1: chart version default bump.
+3. US2: document IAM policy parity result.
+4. Polish and validation.


### PR DESCRIPTION
Bump the module default chart version 3.3.0 -> 3.4.2 (latest stable on eks-charts). The controller image follows the chart appVersion (v3.4.2) since image.tag defaults to null. Verified the vendored iam-policy.json is equivalent to the upstream controller IAM policy for the target version (no permission delta between v3.3.0 and v3.4.2), so the policy is unchanged.

README input table and examples/basic updated to match. Defaults-only, backward-compatible; consumers pinning chart.version are unaffected. Adds spec-kit feature docs under specs/003-upgrade-alb-controller-version.